### PR TITLE
Add new config option for sending an `already formatted record`

### DIFF
--- a/fluent-plugin-raygun.gemspec
+++ b/fluent-plugin-raygun.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-raygun"
-  spec.version       = "0.0.1"
+  spec.version       = "0.0.2"
   spec.authors       = ["Taylor Lodge"]
   spec.email         = ["taylor@raygun.io"]
   spec.summary       = %q{Fluentd output plugin that sends aggregated errors/exception events to Raygun. Raygun is a error logging and aggregation platform.}


### PR DESCRIPTION
The method `notify_raygun` used to have:

...
  payload = {
      occurredOn: Time.at(time).utc.iso8601,
      details: {
        machineName: @hostname,
        error: {
          message: record['messages']
        },
        tags: [tag]
      }
    }
...

because the default logging record from fluentd is
a collection of messages with the key "messages":

...
`https://www.fluentd.org/datasources/rails`

2014-07-07 19:39:01 +0000 foo: {"messages":"{"meth...
...

However there could be times when the record hits this
fluent output plugin and the record/payload is already
in the desired format.

So I've added the `already formatted record` flag/config
to simply pass the record on directly as the payload.

For example I've already shapped the incoming record
to meet one of Rayguns APIs
https://raygun.com/docs/integrations/api
and I don't want it changed.